### PR TITLE
Updates to match template (workflows)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -17,6 +17,8 @@ permissions:
   contents: write
 
 jobs:
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
@@ -24,19 +26,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_start:
     name: On start
     needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 0
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 0}}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 0 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -44,7 +50,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 

--- a/.github/workflows/1-copilot-extension.yml
+++ b/.github/workflows/1-copilot-extension.yml
@@ -21,10 +21,8 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
@@ -32,19 +30,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_add_devcontainer:
     name: On Add Devcontainer
     needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 1
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 1 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 1 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -52,17 +54,17 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      # Verify the learner added the file contents
-      - name: Check workflow contents, jobs
+      # Verify the Copilot extension is present
+      - name: Check Copilot extension
         run: |
           chmod a+x .github/script/check-file.sh
           ./.github/script/check-file.sh
         env:
           FILE: ".devcontainer/devcontainer.json"
           SEARCH: "GitHub.copilot"
-      
+
       # Update README to close <details id=1> and open <details id=2>
       # and set STEP to '2'
       - name: Update to step 2

--- a/.github/workflows/2-skills-javascript.yml
+++ b/.github/workflows/2-skills-javascript.yml
@@ -21,30 +21,32 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_functionadded:
     name: On Creation of a Javascript function
     needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 2
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 2 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 2 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -56,8 +58,8 @@ jobs:
         with:
           fetch-depth: 0 # Let's get all the branches
 
-      # Verify the PR updated package.json
-      - name: Check package.json
+      # Verify the calculate numbers function is present
+      - name: Check skills.js
         run: |
           chmod a+x .github/script/check-file.sh
           ./.github/script/check-file.sh
@@ -65,7 +67,6 @@ jobs:
           FILE: "skills.js"
           SEARCH: "function calculateNumbers"
 
-          
       # Update README to close <details id=2> and open <details id=3>
       # and set STEP to '3'
       - name: Update to step 3

--- a/.github/workflows/3-copilot-hub.yml
+++ b/.github/workflows/3-copilot-hub.yml
@@ -21,30 +21,32 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_Copilothubsuggestions:
     name: On Copilot hub suggestion
     needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 3
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 3 }}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 3 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -57,15 +59,14 @@ jobs:
           fetch-depth: 0 # Let's get all the branches
 
       # Verify the skills member function is present
-      - name: Check package for axios version 0.21.2
+      - name: Check member.js
         run: |
           chmod a+x .github/script/check-file.sh
           ./.github/script/check-file.sh
         env:
           FILE: "member.js"
           SEARCH: "skillsMember"
-          
-          
+
       # Update README to close <details id=3> and open <details id=4>
       # and set STEP to '4'
       - name: Update to step 4

--- a/.github/workflows/4-copilot-comment.yml
+++ b/.github/workflows/4-copilot-comment.yml
@@ -1,4 +1,5 @@
 name: Step 4, 4-Add Copilot suggestion from comment
+
 # This step triggers after push to main#comments.js
 # This step sets STEP to X
 # This step closes <details id=3> and opens <details X>
@@ -12,7 +13,7 @@ on:
       - main
     paths:
       - 'comments.js'
-      
+
 # Reference https://docs.github.com/en/actions/security-guides/automatic-token-authentication
 permissions:
   # Need `contents: read` to checkout the repository
@@ -20,10 +21,8 @@ permissions:
   contents: write
 
 jobs:
-  # The purpose of this job is to output the current step number 
-  # (retreived from the STEP file). This output variable can
-  # then be referenced in other jobs and used in conditional 
-  # expressions.
+  # Get the current step from .github/script/STEP so we can
+  # limit running the main job when the learner is on the same step.
   get_current_step:
     name: Check current step number
     runs-on: ubuntu-latest
@@ -31,19 +30,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - id: get_step
-        run: echo "::set-output name=current_step::$(cat ./.github/script/STEP)"
+        run: |
+          echo "current_step=$(cat ./.github/script/STEP)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
-      
+
   on_push_to_comments:
     name: On code generated from comment
     needs: get_current_step
 
     # We will only run this action when:
     # 1. This repository isn't the template repository
+    # 2. The STEP is currently 4
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ !github.event.repository.is_template && needs.get_current_step.outputs.current_step == 4}}
+    if: >-
+      ${{ !github.event.repository.is_template
+          && needs.get_current_step.outputs.current_step == 4}}
 
     # We'll run Ubuntu for performance instead of Mac or Windows
     runs-on: ubuntu-latest
@@ -51,7 +54,7 @@ jobs:
     steps:
       # We'll need to check out the repository so that we can edit the README
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Let's get all the branches
 
@@ -63,7 +66,7 @@ jobs:
         env:
           FILE: "comments.js"
           SEARCH: "Create web server"
-          
+
       # Update README to close <details id=3> and open <details id=X>
       # and set STEP to 'X'
       - name: Update to step X


### PR DESCRIPTION
Bump actions/checkout@v2 to v3
Stop using set-output commands

### Why:

2 warnings
**Check current step number** and **On start**
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
**Check current step number**
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- Bump actions/checkout@v2 to v3
- Stop using `set-output` commands
- Minor edits
- Create dependabot.yml

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
