### PR TITLE
Explicitly trigger the Autograding workflow after skills/action-update-step

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -56,3 +56,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 0
           to_step: 1
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/1-copilot-extension.yml
+++ b/.github/workflows/1-copilot-extension.yml
@@ -67,3 +67,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 1
           to_step: 2
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2-skills-javascript.yml
+++ b/.github/workflows/2-skills-javascript.yml
@@ -69,3 +69,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 2
           to_step: 3
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/3-copilot-hub.yml
+++ b/.github/workflows/3-copilot-hub.yml
@@ -69,3 +69,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 3
           to_step: 4
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/4-copilot-comment.yml
+++ b/.github/workflows/4-copilot-comment.yml
@@ -69,3 +69,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           from_step: 4
           to_step: X
+
+      # Commits pushed by an Action will not create a new workflow run. To work
+      # around this, create a repository_dispatch event to ensure that GitHub
+      # Classroom's autograding workflow runs on the commit created by
+      # skills/action-update-step.
+      # Reference: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+      - name: Trigger autograding workflow
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/dispatches" \
+            -f "event_type=autograde"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

Tasks performed by the GitHub Actions `GITHUB_TOKEN`, such as commit pushes, [do not create new workflow runs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). This means that the commit and push performed by our `skills/action-update-step@v2` steps are not triggering GitHub Classroom's autograding workflow, which in turn is preventing learners from having their Experience marked as complete after they finish the final step.

### Changes

The autograding workflow is created with a `repository_dispatch` trigger. This modifies our Actions workflows to manually create a `repository_dispatch` event on the repository after the step update commit has been pushed, causing autograding to run _after_ the `-step.txt` file has received its final update, at which point it will be able to succeed.

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
